### PR TITLE
Minor improvements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,24 @@
-# SCD30 driver
+# SCD30
 
-Driver for the [SCD30 sensor](https://www.sensirion.com/en/environmental-sensors/carbon-dioxide-sensors/carbon-dioxide-sensors-scd30/).
+Driver for the Sensirion SCD30 sensor module, for monitoring CO2, temperature, and humidity.
 
 ## Usage
 
-The ESP32 pin connection to the SCD30 sensor is as follows:
-
-- GPIO21 > SDA
-- GPIO22 > SCL
-- 3.3V > 3V
-- GND > GND
+Installation: `toit pkg install github.com/qvisten999/scd30`
 
 ```
 import scd30
 
 main:
-    ...
+  ...
 ```
 
-See the `examples` folder for more examples
-
-Installation: `toit pkg install github.com/qvisten999/scd30`
+See the `examples` folder for examples.
 
 ## References
 
-[Datasheet](https://www.sensirion.com/en/environmental-sensors/carbon-dioxide-sensors/carbon-dioxide-sensors-scd30/)
+[Official site](https://www.sensirion.com/en/environmental-sensors/carbon-dioxide-sensors/carbon-dioxide-sensors-scd30/)
+[Datasheet](https://www.sensirion.com/fileadmin/user_upload/customers/sensirion/Dokumente/9.5_CO2/Sensirion_CO2_Sensors_SCD30_Datasheet.pdf)
 
 ## Features and bugs
 

--- a/examples/room.toit
+++ b/examples/room.toit
@@ -2,6 +2,17 @@
 // Use of this source code is governed by a MIT-style license that can be found
 // in the LICENSE file.
 
+/**
+Small example to show the use of the CO2 sensor.
+
+The ESP32 pin connection to the SCD30 sensor is as follows:
+
+- GPIO21 > SDA
+- GPIO22 > SCL
+- 3.3V > 3V
+- GND > GND
+*/
+
 import gpio
 import i2c
 import ..src.scd30


### PR DESCRIPTION
Change the name of the package to `scd30` instead of `scd30_driver`.

Move the pin-layout to the example that actually uses it.